### PR TITLE
Improved header style

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -198,7 +198,6 @@
 		opacity: 0;
 		position: relative;
 		text-align: center;
-		top: -1em;
 		width: 90%;
 	}
 


### PR DESCRIPTION
There's a bug when viewing this website in Chrome (but it's fine in Firefox)...
I noticed that the header (title and social icons) are misplaced whenever the chrome browser is not maximized, so I made a little bit change.
